### PR TITLE
Crosslink capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 peptideB
 ========
-Tristan Bereau 
+Original work by Tristan Bereau. Modified by Jingjie Yeo.
 
 Model
 -----
 This software simulates a peptide model described in:
 
 > T. Bereau, M. Deserno, J Chem Phys 130, 235106 (2009) [Journal][jpc]
+
+Crosslinking capabilities are being added but these changes HAVE NOT been fully tested yet.
 
 Program
 -------

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ Usage
 peptideB's documentation can be found on its [Wiki page](https://github.com/tbereau/peptideB/wiki).
 
 
-[jpc]: http://link.aip.org/link/doi/10.1063/1.3152842
+[jpc]: http://aip.scitation.org/doi/full/10.1063/1.3152842
 [![githalytics.com alpha](https://cruel-carlota.pagodabox.com/1adc9e622abb43b177d23674afdc5238 "githalytics.com")](http://githalytics.com/tbereau/peptideB)

--- a/peptidebuilder.tcl
+++ b/peptidebuilder.tcl
@@ -262,14 +262,20 @@ namespace eval peptideb {
 	    } "-freeze" {
 		set freeze 1
 		::mmsg::send $this "Atoms with 0.00 occupancy will be fixed"
-	    } default {
-		mmsg::err $this "Wrong argument [lindex $argv $k] -- exiting."
 	    } "-crosslink" {
 		set crosslink 1
+		
 		set crosslink_file [lindex $argv [expr $k+1]]
-		mmsg::send $this "Loaded index of crosslinked atomIDs from $crosslink_file."		
-		incr k
-		}
+		set crosslink_spring [lindex $argv [expr $k+2]]
+		set crosslink_cut [lindex $argv [expr $k+3]]
+		
+		mmsg::send $this "Loaded index of crosslinked atomIDs from $crosslink_file."
+		mmsg::send $this "Crosslink spring constant is $crosslink_spring and cutoff is $crosslink_cut."
+		
+		incr k 3
+	    } default {
+		mmsg::err $this "Wrong argument [lindex $argv $k] -- exiting."
+	    } 
 	}
     }
     

--- a/peptidebuilder.tcl
+++ b/peptidebuilder.tcl
@@ -71,6 +71,7 @@ set usage "Usage:
 \t-randequilib \t\t choose dihedrals randomly from an equilibrated basin (no high free energy configurations)
 \t-virtual_com N \t\t add virtual site: center of mass of peptide number N (starting from 1)
 \t-freeze \t\t freeze atoms that have 0.00 occupancy in input PDB
+\t-crosslink \t\t create crosslinks between atoms in user-specified file
 "
 
 # ----------------------------------------------------------- #
@@ -104,6 +105,7 @@ namespace eval peptideb {
     set virtual_com -1
     set freeze 0
     set frozen ""
+    set crosslink 0
 
     # Read the amino acids sequence, plus other parameters. Sequence can be accessed by $amino_acids.
     source $paramsfile
@@ -262,7 +264,12 @@ namespace eval peptideb {
 		::mmsg::send $this "Atoms with 0.00 occupancy will be fixed"
 	    } default {
 		mmsg::err $this "Wrong argument [lindex $argv $k] -- exiting."
-	    }
+	    } "-crosslink" {
+		set crosslink 1
+		set crosslink_file [lindex $argv [expr $k+1]]
+		mmsg::send $this "Loaded index of crosslinked atomIDs from $crosslink_file."		
+		incr k
+		}
 	}
     }
     
@@ -556,7 +563,13 @@ namespace eval peptideb {
 
 	# Write a vmd startup file.
 	output::pdbstartup
-	
+		
+	if { [info exists crosslink_file]} {
+		# Import the crosslink file.
+		set fp [open "$crosslink_file" "r"]
+		set crosslinkAtomIDS [ read $fp ]
+		close $fp
+	}
 	
 	if { $espresso == "on"} {
 	    # Output the initial configuration to ESPResSo without
@@ -571,6 +584,7 @@ namespace eval peptideb {
 	    output::pdb $coords
 	}
     }
+	
 
 
     # Delete hostfile for replica exchange

--- a/src/espresso/topology.tcl
+++ b/src/espresso/topology.tcl
@@ -324,7 +324,8 @@ namespace eval peptideb {
                 
         # Add crosslinks        
         if { $peptideb::crosslink } {
-		inter 40 harmonic 300 15
+		inter 40 harmonic $peptideb::crosslink_spring $peptideb::crosslink_cut
+		
 		foreach {crosslink1 crosslink2} $peptideb::crosslinkAtomIDS {
 		part $crosslink1 bond 40 $crosslink2
 		::mmsg::send [namespace current] "Crosslinked atoms $crosslink1 and $crosslink2."

--- a/src/espresso/topology.tcl
+++ b/src/espresso/topology.tcl
@@ -321,18 +321,15 @@ namespace eval peptideb {
         # partners linked by 1 one or 2 bonds.
         part auto_exclusions 2
         }
-        
-        
+                
         # Add crosslinks        
         if { $peptideb::crosslink } {
-        
-		  inter 40 harmonic 100 15
-        
-		  foreach {crosslink1 crosslink2} $peptideb::crosslinkAtomIDS {
-            part $crosslink1 bond 40 $crosslink2
-            ::mmsg::send [namespace current] "Crosslinked atomIDs are $crosslink1 $crosslink2."
-			}
-		  }
+		inter 40 harmonic 300 15
+		foreach {crosslink1 crosslink2} $peptideb::crosslinkAtomIDS {
+		part $crosslink1 bond 40 $crosslink2
+		::mmsg::send [namespace current] "Crosslinked atoms $crosslink1 and $crosslink2."
+		}
+	}
 
         return 
     }

--- a/src/espresso/topology.tcl
+++ b/src/espresso/topology.tcl
@@ -321,6 +321,18 @@ namespace eval peptideb {
         # partners linked by 1 one or 2 bonds.
         part auto_exclusions 2
         }
+        
+        
+        # Add crosslinks        
+        if { $peptideb::crosslink } {
+        
+		  inter 40 harmonic 100 15
+        
+		  foreach {crosslink1 crosslink2} $peptideb::crosslinkAtomIDS {
+            part $crosslink1 bond 40 $crosslink2
+            ::mmsg::send [namespace current] "Crosslinked atomIDs are $crosslink1 $crosslink2."
+			}
+		  }
 
         return 
     }


### PR DESCRIPTION
Added ability to crosslink atoms with a simple harmonic potential by supplying a two-column text file specifying pairs of atoms to crosslink. Users are also able to specify the crosslink spring constant and cutoff distance.